### PR TITLE
fix: grant write permissions and fix deprecated set-output command

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -15,11 +15,14 @@ jobs:
   scrape:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v3
 
       - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
         id: nvm
 
       - name: Setup node

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Generate data
         run: npm run generate
 
+      - name: Pull latest changes before commit
+        run: git pull --rebase origin master
+
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Auto-update data.


### PR DESCRIPTION
Add `permissions: contents: write` to the scrape job so the default
GITHUB_TOKEN can push commits via git-auto-commit-action.

Also replace the deprecated `::set-output` syntax with the current
`$GITHUB_OUTPUT` environment file approach to fix node version detection.

https://claude.ai/code/session_017q1BQqWdJAx3qPDbPqXTqa